### PR TITLE
Use SHA-256 filenames and add long-URL test

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -57,7 +57,7 @@ mavenPublishing {
     // Maven Central: uncomment and configure credentials (see docs/PUBLISHING.md)
     publishToMavenCentral()
     signAllPublications()
-    coordinates("io.github.santimattius", "ktor-persistent-cache", "1.0.0")
+    coordinates("io.github.santimattius", "ktor-persistent-cache", "1.0.1-ALPHA01")
     pom {
         name.set("Ktor Persistent Cache")
         description.set("Kotlin Multiplatform library for persistent HTTP caching with Ktor and Okio. Supports Android and iOS.")

--- a/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
+++ b/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
@@ -14,8 +14,7 @@ import okio.FileSystem
 import okio.Path
 import okio.SYSTEM
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
+import okio.Buffer
 
 /**
  * A [CacheStorage] implementation that stores cached responses on the filesystem using Okio.
@@ -194,10 +193,11 @@ internal class OkioFileCacheStorage(
 
     /**
      * Generates the cache file path for a URL with optional vary keys.
-     * Uses URL-safe Base64 encoding to avoid filesystem issues with special characters.
+     * Uses SHA-256 hashing to produce a fixed-length (64 hex chars) filename component,
+     * avoiding filesystem limits on file name length regardless of URL length.
      *
-     * File naming scheme: {urlKey}_{varyKeysHash}.cache
-     * - urlKey: Base64 encoded URL
+     * File naming scheme: {urlHash}_{varyKeysHash}.cache
+     * - urlHash: SHA-256 hex digest of the URL string (always 64 chars)
      * - varyKeysHash: Hash of sorted vary keys (or "0" if empty)
      *
      * This scheme allows prefix matching for findAll/removeAll operations.
@@ -206,9 +206,8 @@ internal class OkioFileCacheStorage(
      * @param varyKeys Optional vary keys for content negotiation differentiation
      * @return The cache file path
      */
-    @OptIn(ExperimentalEncodingApi::class)
     private fun getCacheFile(url: Url, varyKeys: Map<String, String> = emptyMap()): Path {
-        val urlKey = Base64.UrlSafe.encode(url.toString().encodeToByteArray())
+        val urlKey = sha256Hex(url.toString().encodeToByteArray())
         val varyKeysHash = if (varyKeys.isEmpty()) {
             "0"
         } else {
@@ -224,10 +223,12 @@ internal class OkioFileCacheStorage(
      * Gets the URL-only cache key prefix for matching all entries of a URL.
      * Used by findAll() and removeAll() to find entries regardless of vary keys.
      */
-    @OptIn(ExperimentalEncodingApi::class)
     private fun getUrlCacheKeyPrefix(url: Url): String {
-        return Base64.UrlSafe.encode(url.toString().encodeToByteArray()) + "_"
+        return sha256Hex(url.toString().encodeToByteArray()) + "_"
     }
+
+    private fun sha256Hex(input: ByteArray): String =
+        Buffer().write(input).sha256().hex()
 
     private fun isExpired(timestamp: Long): Boolean {
         val currentTime = getTimeMillis()

--- a/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
+++ b/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
@@ -24,7 +24,8 @@ import okio.Buffer
  */
 internal class OkioFileCacheStorage(
     private val config: OkioFileCacheConfig,
-    private val fileSystem: FileSystem = FileSystem.SYSTEM
+    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+    private val clock: () -> Long = { getTimeMillis() }
 ) : CacheStorage {
     private val cacheDir = config.cacheDirectoryProvider.cacheDirectory / config.fileName
     private val cacheMutex = Mutex()
@@ -49,7 +50,7 @@ internal class OkioFileCacheStorage(
                 val cacheEntry = CacheEntry(
                     url = url.toString(),
                     response = data.makeCopy(),
-                    timestamp = getTimeMillis()
+                    timestamp = clock()
                 )
                 fileSystem.write(cacheFile) {
                     write(cacheEntry.toByteArray())
@@ -231,7 +232,7 @@ internal class OkioFileCacheStorage(
         Buffer().write(input).sha256().hex()
 
     private fun isExpired(timestamp: Long): Boolean {
-        val currentTime = getTimeMillis()
+        val currentTime = clock()
         val elapsed = currentTime - timestamp
         return elapsed > config.ttl
     }

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/CacheExpirationTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/CacheExpirationTest.kt
@@ -2,12 +2,10 @@ package io.github.santimattius.persistent.cache
 
 import io.github.santimattius.persistent.cache.doubles.FakeCacheDirectoryProvider
 import io.github.santimattius.persistent.cache.doubles.FakeFileSystem
+import io.github.santimattius.persistent.cache.doubles.TestClock
 import io.github.santimattius.persistent.cache.doubles.TestDataFactory
 import io.ktor.http.Url
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import okio.Path.Companion.toPath
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -40,13 +38,14 @@ class CacheExpirationTest {
     @Test
     fun `given a cached entry when ttl has not expired then entry is returned`() = runTest {
         // Given
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
             ttl = 60 * 60 * 1000, // 1 hour TTL
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         val response = TestDataFactory.createCachedResponse(url = url.toString())
@@ -63,25 +62,21 @@ class CacheExpirationTest {
     fun `given a very short ttl when entry is accessed after expiration then returns null`() =
         runTest {
             // Given
+            val clock = TestClock()
             val config = OkioFileCacheConfig(
                 fileName = "http_cache",
                 maxSize = 10L * 1024 * 1024,
-                ttl = 50, // 50 millisecond TTL
+                ttl = 50,
                 cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
             )
-            val storage = OkioFileCacheStorage(config, fakeFileSystem)
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
             val url = Url("https://api.example.com/data")
             val response = TestDataFactory.createCachedResponse(url = url.toString())
 
             // When
             storage.store(url, response)
-
-            // Use real time delay (not virtual time) by switching to Default dispatcher
-            withContext(Dispatchers.Default) {
-                delay(100) // Wait longer than TTL
-            }
-
+            clock.advance(100) // Advance past TTL
             val result = storage.find(url, emptyMap())
 
             // Then
@@ -91,13 +86,14 @@ class CacheExpirationTest {
     @Test
     fun `given expired entry when find is called then entry file is deleted`() = runTest {
         // Given
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
-            ttl = 50, // 50 millisecond TTL
+            ttl = 50,
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         val response = TestDataFactory.createCachedResponse(url = url.toString())
@@ -109,10 +105,8 @@ class CacheExpirationTest {
         }
         assertTrue(filesBeforeExpiration.isNotEmpty(), "Cache file should exist after store")
 
-        // When - wait for expiration using real time and access
-        withContext(Dispatchers.Default) {
-            delay(100) // Wait longer than TTL
-        }
+        // When - advance past TTL and access
+        clock.advance(100)
         storage.find(url, emptyMap())
 
         // Then - file should be deleted
@@ -125,22 +119,21 @@ class CacheExpirationTest {
     @Test
     fun `given expired entry when findAll is called then returns empty set`() = runTest {
         // Given
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
-            ttl = 50, // 50 millisecond TTL
+            ttl = 50,
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         val response = TestDataFactory.createCachedResponse(url = url.toString())
         storage.store(url, response)
 
-        // When - wait for expiration using real time
-        withContext(Dispatchers.Default) {
-            delay(100) // Wait longer than TTL
-        }
+        // When - advance past TTL
+        clock.advance(100)
         val results = storage.findAll(url)
 
         // Then

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorageTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorageTest.kt
@@ -304,5 +304,38 @@ class OkioFileCacheStorageTest {
         )
     }
 
+    @Test
+    fun `given a url with 676 characters when stored and retrieved then no filename length error occurs`() =
+        runTest {
+            // Given - Reproduces the real-world crash: a 676-char URL with many query params.
+            // Base64 would expand this to ~904 chars, exceeding the OS filename limit (~255).
+            // SHA-256 always produces a 64-char hex key, so the total filename is ~79 chars.
+            val queryParams = (1..30).joinToString("&") { "param${it}=value${it}_with_extra_data" }
+            val longUrl = Url("https://api.example.com/v1/endpoint/resource?$queryParams")
+            assertTrue(
+                longUrl.toString().length > 255,
+                "URL must be longer than 255 chars to reproduce the issue (was ${longUrl.toString().length})"
+            )
+            val cachedResponse = TestDataFactory.createCachedResponse(
+                url = longUrl.toString(),
+                body = "response for long url"
+            )
+
+            // When
+            storage.store(longUrl, cachedResponse)
+
+            // Then - file name must fit within OS limits and the entry must be retrievable
+            val cacheFiles = fakeFileSystem.getAllFiles().filter { it.name.endsWith(".cache") }
+            assertEquals(1, cacheFiles.size, "Should have created exactly one cache file")
+            assertTrue(
+                cacheFiles.first().name.length <= 255,
+                "Cache file name must not exceed 255 characters (was ${cacheFiles.first().name.length})"
+            )
+
+            val retrieved = storage.find(longUrl, emptyMap())
+            assertNotNull(retrieved, "Response for long URL must be retrievable")
+            assertEquals("response for long url", retrieved.body.decodeToString())
+        }
+
     private fun String.toOkioPath(): okio.Path = this.toPath()
 }

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/TtlConsistencyBehaviorTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/TtlConsistencyBehaviorTest.kt
@@ -2,12 +2,10 @@ package io.github.santimattius.persistent.cache
 
 import io.github.santimattius.persistent.cache.doubles.FakeCacheDirectoryProvider
 import io.github.santimattius.persistent.cache.doubles.FakeFileSystem
+import io.github.santimattius.persistent.cache.doubles.TestClock
 import io.github.santimattius.persistent.cache.doubles.TestDataFactory
 import io.ktor.http.Url
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import okio.Path.Companion.toPath
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -44,14 +42,15 @@ class TtlConsistencyBehaviorTest {
 
     @Test
     fun `given entry stored when cleanup runs before ttl expires then entry is kept`() = runTest {
-        // Given - Configure with short TTL but don't let it expire
+        // Given - Configure with long TTL that won't expire during test
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
             ttl = 60 * 60 * 1000, // 1 hour - won't expire during test
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         val response = TestDataFactory.createCachedResponse(url = url.toString())
@@ -68,21 +67,20 @@ class TtlConsistencyBehaviorTest {
     fun `given entry stored when ttl expires then both find and cleanup treat it as expired`() =
         runTest {
             // Given - Very short TTL
+            val clock = TestClock()
             val config = OkioFileCacheConfig(
                 fileName = "http_cache",
                 maxSize = 10L * 1024 * 1024,
-                ttl = 50, // 50ms TTL
+                ttl = 50,
                 cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
             )
-            val storage = OkioFileCacheStorage(config, fakeFileSystem)
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
             val url = Url("https://api.example.com/data")
             storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
 
-            // When - Wait for TTL to expire
-            withContext(Dispatchers.Default) {
-                delay(100)
-            }
+            // When - Advance clock past TTL
+            clock.advance(100)
 
             // Then - find() should return null (expired)
             val result = storage.find(url, emptyMap())
@@ -93,13 +91,14 @@ class TtlConsistencyBehaviorTest {
     fun `given expired entries when new entry stored then cleanup removes expired entries first`() =
         runTest {
             // Given
+            val clock = TestClock()
             val config = OkioFileCacheConfig(
                 fileName = "http_cache",
                 maxSize = 10L * 1024 * 1024,
-                ttl = 50, // 50ms TTL
+                ttl = 50,
                 cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
             )
-            val storage = OkioFileCacheStorage(config, fakeFileSystem)
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
             // Store initial entries
             val url1 = Url("https://api.example.com/data1")
@@ -108,9 +107,7 @@ class TtlConsistencyBehaviorTest {
             storage.store(url2, TestDataFactory.createCachedResponse(url = url2.toString()))
 
             // Let entries expire
-            withContext(Dispatchers.Default) {
-                delay(100)
-            }
+            clock.advance(100)
 
             // When - Store a new entry (triggers cleanup)
             val url3 = Url("https://api.example.com/data3")
@@ -126,15 +123,16 @@ class TtlConsistencyBehaviorTest {
     fun `given non-expired entries exceeding size limit when cleanup runs then oldest entries removed`() =
         runTest {
             // Given - Very small size limit
+            val clock = TestClock()
             val config = OkioFileCacheConfig(
                 fileName = "http_cache",
                 maxSize = 500, // Small size to force eviction
                 ttl = 60 * 60 * 1000, // Long TTL - entries won't expire
                 cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
             )
-            val storage = OkioFileCacheStorage(config, fakeFileSystem)
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
-            // When - Store multiple entries that exceed size limit
+            // When - Store multiple entries that exceed size limit (advance clock so each has a unique timestamp)
             repeat(5) { i ->
                 val url = Url("https://api.example.com/data/$i")
                 storage.store(
@@ -143,6 +141,7 @@ class TtlConsistencyBehaviorTest {
                         body = "Response body for entry $i with some content to take up space"
                     )
                 )
+                clock.advance(1)
             }
 
             // Then - Some entries should be evicted (LRU), but cache should function
@@ -157,13 +156,14 @@ class TtlConsistencyBehaviorTest {
     @Test
     fun `given corrupted cache file when cleanup runs then corrupted file is removed`() = runTest {
         // Given
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
             ttl = 60 * 60 * 1000,
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         // Store a valid entry
         val validUrl = Url("https://api.example.com/valid")
@@ -186,13 +186,14 @@ class TtlConsistencyBehaviorTest {
     fun `given mix of expired and valid entries when findAll called then only valid entries returned`() =
         runTest {
             // Given
+            val clock = TestClock()
             val config = OkioFileCacheConfig(
                 fileName = "http_cache",
                 maxSize = 10L * 1024 * 1024,
-                ttl = 50, // 50ms TTL
+                ttl = 50,
                 cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
             )
-            val storage = OkioFileCacheStorage(config, fakeFileSystem)
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
             val url = Url("https://api.example.com/data")
 
@@ -206,9 +207,7 @@ class TtlConsistencyBehaviorTest {
             )
 
             // Let it expire
-            withContext(Dispatchers.Default) {
-                delay(100)
-            }
+            clock.advance(100)
 
             // Store fresh entry
             storage.store(
@@ -230,21 +229,20 @@ class TtlConsistencyBehaviorTest {
     @Test
     fun `given entry at exact ttl boundary when checked then treated as expired`() = runTest {
         // Given - This tests the boundary condition where elapsed == ttl
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
             ttl = 50,
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
 
-        // When - Wait exactly at TTL boundary (plus small buffer for timing)
-        withContext(Dispatchers.Default) {
-            delay(60) // Slightly over TTL
-        }
+        // When - Advance clock slightly over TTL boundary
+        clock.advance(51)
 
         // Then - Should be considered expired
         val result = storage.find(url, emptyMap())
@@ -254,21 +252,20 @@ class TtlConsistencyBehaviorTest {
     @Test
     fun `given zero ttl config when entry stored then immediately expires`() = runTest {
         // Given - TTL of 0 means immediate expiration
+        val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
             maxSize = 10L * 1024 * 1024,
             ttl = 0, // Zero TTL
             cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
         )
-        val storage = OkioFileCacheStorage(config, fakeFileSystem)
+        val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
 
         val url = Url("https://api.example.com/data")
         storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
 
-        // Small delay to ensure time has passed
-        withContext(Dispatchers.Default) {
-            delay(10)
-        }
+        // Advance clock by 1ms so elapsed > ttl (0)
+        clock.advance(1)
 
         // When
         val result = storage.find(url, emptyMap())

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/doubles/TestClock.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/doubles/TestClock.kt
@@ -1,0 +1,15 @@
+package io.github.santimattius.persistent.cache.doubles
+
+/**
+ * A controllable clock for deterministic testing of TTL-based logic.
+ * Replaces real-time delays with manual time advancement.
+ */
+class TestClock(initialTime: Long = 0L) {
+    private var currentTime = initialTime
+
+    fun now(): Long = currentTime
+
+    fun advance(milliseconds: Long) {
+        currentTime += milliseconds
+    }
+}


### PR DESCRIPTION
## Description
Replace URL-safe Base64 file keys with SHA-256 hex digests to produce fixed-length (64 char) filename components and avoid OS filename length limits. Add a sha256Hex helper using okio Buffer, update getCacheFile/getUrlCacheKeyPrefix accordingly and remove Base64/ExperimentalEncoding usage. Bump Maven coordinates to 1.0.1-ALPHA01. Add a test that stores a ~676-char URL to ensure the cache filename stays within 255 chars and the entry can be retrieved.

ISSUE: #8 