### PR TITLE
[fix] issue 25 android context persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,14 @@ If you **don’t** use the library’s manifest (e.g. you use a different DI or 
 call **once** at app startup with the **application context** (not an Activity context):
 
 ```kotlin
+import io.github.santimattius.persistent.cache.startup.injectContext
+
 // e.g. in Application.onCreate()
 injectContext(applicationContext)
 ```
 
-`injectContext` is provided by the library package
-`io.github.santimattius.persistent.cache.startup`.
+`injectContext` is a **public** API in `io.github.santimattius.persistent.cache.startup`. It throws
+`IllegalArgumentException` if you pass a context that can leak memory (for example an Activity).
 
 ### iOS
 
@@ -164,6 +166,12 @@ val client = HttpClient(CIO) {
 2. Use the client as usual. The cache stores responses for requests that support caching and serves
    them when valid.
 
+   **Cross-restart persistence** depends on the **origin server's** cacheability headers per
+   [RFC 7234](https://www.rfc-editor.org/rfc/rfc7234) (for example `Cache-Control: max-age=…` or
+   `Expires`). This library persists whatever Ktor's [HttpCache](https://ktor.io/docs/client-caching.html)
+   plugin stores; it does not override freshness rules. Responses marked `no-store` are not written
+   to disk.
+
 ```kotlin
 val response: String = client.get("https://example.com/api/data").body()
 ```
@@ -182,7 +190,7 @@ val response: String = client.get("https://example.com/api/data").body()
 | `enabled`        | `Boolean` | `false`        | Whether the HTTP cache is enabled.                                                                                          |
 | `cacheDirectory` | `String`  | `"http_cache"` | Name of the cache directory under the platform cache root.                                                                  |
 | `maxCacheSize`   | `Long`    | 10 MB          | Maximum cache size in bytes. LRU eviction when exceeded. Use `0` for no limit.                                              |
-| `cacheTtl`       | `Long`    | 1 hour         | Time-to-live for entries in milliseconds.                                                                                   |
+| `cacheTtl`       | `Long`    | 1 hour         | Time-to-live for entries in milliseconds. Values `<= 0` mean entries **never expire** (same convention as `maxCacheSize <= 0` = unlimited). |
 | `isShared`       | `Boolean` | `true`         | Whether the cache is shared across requests (Ktor [HttpCache](https://ktor.io/docs/client-caching.html) behavior).          |
 | `isPublic`       | `Boolean` | `false`        | When `true`, cached responses are treated as public (shareable across users); when `false`, they are private to the client. |
 
@@ -194,6 +202,23 @@ CacheConfig(enabled = true, cacheDirectory = "my_cache")
 ```
 
 [CacheConfig]: shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/CacheConfig.kt
+
+### Auth plugin + persistent cache
+
+This library installs Ktor's [HttpCache](https://ktor.io/docs/client-caching.html) and does **not**
+intercept the Auth pipeline. When you also install [Auth](https://ktor.io/docs/client-auth.html),
+behavior follows Ktor's cache routing:
+
+- Authenticated responses need **`Cache-Control: private`** (for example `private, max-age=3600`) to
+  be stored in **private** storage — the Okio-backed store configured by `installPersistentCache`
+  when `isPublic = false`. Responses with only `max-age` (no `private`) route to Ktor's default
+  public storage, which this helper does not configure.
+- Set **`isShared = false`** on [CacheConfig] when using Bearer (or other) auth on the same client.
+  Ktor skips cache lookup for authorized requests on a shared client and refuses to store private
+  entries when `isShared = true`.
+
+These rules are verified by `AuthPluginInteropTest` in the test suite. No extra configuration is
+required beyond matching server cache headers and the `CacheConfig` flags above.
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,8 @@ kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-seria
 
 #Ktor
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktorVersion" }
+ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktorVersion" }
 # Okio
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -46,6 +46,8 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.ktor.client.auth)
         }
     }
 }

--- a/shared/src/androidMain/kotlin/io/github/santimattius/persistent/cache/startup/ContextInitializer.kt
+++ b/shared/src/androidMain/kotlin/io/github/santimattius/persistent/cache/startup/ContextInitializer.kt
@@ -65,10 +65,13 @@ private var applicationContext: Context? = null
  * It performs a check using [canLeakMemory] to ensure that the provided context is not one that
  * could cause memory leaks if stored statically (e.g., an Activity context).
  *
+ * Public so external modules can call it manually when AndroidX Startup's automatic
+ * [ContextInitializer] does not run (e.g. it was disabled in the manifest).
+ *
  * @param context The [Context] to be used as the application context.
  * @throws IllegalArgumentException if the provided context is deemed prone to memory leaks.
  */
-internal fun injectContext(context: Context) {
+fun injectContext(context: Context) {
     require(!context.canLeakMemory()) { "The passed $context would leak memory!" }
     applicationContext = context
 }

--- a/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/CacheConfig.kt
+++ b/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/CacheConfig.kt
@@ -10,6 +10,7 @@ package io.github.santimattius.persistent.cache
  * @property cacheDirectory Custom cache directory name (default: "http_cache").
  * @property maxCacheSize Maximum cache size in bytes (default: 10MB).
  * @property cacheTtl Time-to-live for cache entries in milliseconds (default: 1 hour).
+ *   A value `<= 0` means entries never expire.
  * @property isShared Whether the cache is shared across requests (default: true).
  * @property isPublic Whether cached responses are considered public (default: false).
  *   When true, responses may be shared across users; when false, they are private to the client.

--- a/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheConfig.kt
+++ b/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheConfig.kt
@@ -6,6 +6,7 @@ package io.github.santimattius.persistent.cache
  * @property fileName The base name for the cache directory.
  * @property maxSize The maximum size of the cache in bytes.
  * @property ttl The time-to-live for cache entries in milliseconds.
+ *   A value `<= 0` means entries never expire (mirrors `maxSize <= 0` = unlimited).
  * @property cacheDirectoryProvider The provider for the cache directory. If not provided, a default one will be used.
  */
 internal data class OkioFileCacheConfig(

--- a/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
+++ b/shared/src/commonMain/kotlin/io/github/santimattius/persistent/cache/OkioFileCacheStorage.kt
@@ -232,6 +232,7 @@ internal class OkioFileCacheStorage(
         Buffer().write(input).sha256().hex()
 
     private fun isExpired(timestamp: Long): Boolean {
+        if (config.ttl <= 0) return false // ttl <= 0 means "never expires" (mirrors maxSize <= 0 = unlimited)
         val currentTime = clock()
         val elapsed = currentTime - timestamp
         return elapsed > config.ttl

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/AuthPluginInteropTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/AuthPluginInteropTest.kt
@@ -1,0 +1,208 @@
+package io.github.santimattius.persistent.cache
+
+import io.github.santimattius.persistent.cache.doubles.FakeCacheDirectoryProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Auth + persistent-cache coexistence tests per spec (issue #25, domain `ktor-auth-plugin-interop`).
+ *
+ * Exercises an [HttpClient] with both [Auth] (Bearer refresh on 401) and [installPersistentCache]
+ * installed together. Persistence is verified by opening a second client against the same on-disk
+ * cache directory: a cache hit must not invoke [MockEngine] again.
+ *
+ * Ktor routing note (documented here and in README task 5.4): authenticated cacheable responses
+ * must use `Cache-Control: private` to land in [HttpCache.Config.privateStorage] (our Okio-backed
+ * storage). Responses with only `max-age` route to public storage, which [installPersistentCache]
+ * does not configure when [CacheConfig.isPublic] is false. Also, [CacheConfig.isShared] must be
+ * false so Ktor does not skip cache lookup/storage for authorized requests on a "shared" client.
+ */
+class AuthPluginInteropTest {
+
+    private lateinit var cacheRootDir: Path
+
+    @BeforeTest
+    fun setUp() {
+        val uniqueSuffix = Random.nextLong().toString()
+        cacheRootDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "ktor-cache-auth-interop-test-$uniqueSuffix"
+        FileSystem.SYSTEM.createDirectories(cacheRootDir)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        FileSystem.SYSTEM.deleteRecursively(cacheRootDir, mustExist = false)
+    }
+
+    private fun cacheConfig() = CacheConfig(
+        enabled = true,
+        cacheDirectory = "http_cache",
+        maxCacheSize = 10L * 1024 * 1024,
+        cacheTtl = 60 * 60 * 1000,
+        // Unshared client: Ktor skips cache for Authorization when isShared=true (HttpCache.kt:163)
+        // and refuses to store private entries when isShared=true (HttpCache.kt:304).
+        isShared = false,
+        isPublic = false
+    )
+
+    private fun cacheDirectoryProvider() = FakeCacheDirectoryProvider(cacheRootDir.toString())
+
+    private fun authMockEngine(
+        validToken: String,
+        cacheControl: String,
+        body: String,
+        onRequest: () -> Unit = {}
+    ): MockEngine =
+        MockEngine { request ->
+            onRequest()
+            val authHeader = request.headers[HttpHeaders.Authorization]
+            if (authHeader != "Bearer $validToken") {
+                respond(
+                    content = "Unauthorized",
+                    status = HttpStatusCode.Unauthorized,
+                    headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer")
+                )
+            } else {
+                respond(
+                    content = body,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        HttpHeaders.CacheControl to listOf(cacheControl),
+                        HttpHeaders.ContentType to listOf("text/plain")
+                    )
+                )
+            }
+        }
+
+    private fun buildClient(engine: MockEngine): HttpClient =
+        HttpClient(engine) {
+            install(Auth) {
+                bearer {
+                    loadTokens { BearerTokens("expired-access-token", "refresh-token") }
+                    refreshTokens { BearerTokens(VALID_TOKEN, "refresh-token") }
+                }
+            }
+            installPersistentCache(cacheConfig(), cacheDirectoryProvider())
+        }
+
+    @Test
+    fun `given Auth and persistent cache when cacheable authenticated response succeeds then it is persisted`() =
+        runTest {
+            val url = "https://api.example.com/auth-cacheable"
+            val cacheableBody = "authenticated cacheable payload"
+            var mockInvocations = 0
+
+            val engine = authMockEngine(
+                validToken = VALID_TOKEN,
+                // private + max-age routes the entry to privateStorage (Okio), per RFC 7234
+                cacheControl = "private, max-age=3600",
+                body = cacheableBody,
+                onRequest = { mockInvocations++ }
+            )
+
+            val clientA = buildClient(engine)
+            try {
+                val response = clientA.get(url)
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertEquals(cacheableBody, response.bodyAsText())
+                // 401 (expired token) + 200 (after bearer refresh)
+                assertEquals(2, mockInvocations)
+            } finally {
+                clientA.close()
+            }
+
+            val persistedEntries = CacheStorageFactory.create(
+                config = cacheConfig(),
+                fileSystem = FileSystem.SYSTEM,
+                cacheDirectoryProvider = cacheDirectoryProvider()
+            ).findAll(Url(url))
+            assertNotNull(
+                persistedEntries.firstOrNull(),
+                "Cacheable authenticated response with Cache-Control private must be persisted to Okio storage"
+            )
+
+            mockInvocations = 0
+            val clientB = buildClient(engine)
+            try {
+                val cachedResponse = clientB.get(url)
+                assertEquals(HttpStatusCode.OK, cachedResponse.status)
+                assertEquals(cacheableBody, cachedResponse.bodyAsText())
+                assertEquals(
+                    0,
+                    mockInvocations,
+                    "Second client must serve the cacheable response from on-disk cache without hitting MockEngine"
+                )
+            } finally {
+                clientB.close()
+            }
+        }
+
+    @Test
+    fun `given Auth and persistent cache when no-store authenticated response succeeds then it is not persisted`() =
+        runTest {
+            val url = "https://api.example.com/auth-no-store"
+            val noStoreBody = "authenticated no-store payload"
+            var mockInvocations = 0
+
+            val engine = authMockEngine(
+                validToken = VALID_TOKEN,
+                cacheControl = "no-store",
+                body = noStoreBody,
+                onRequest = { mockInvocations++ }
+            )
+
+            val clientA = buildClient(engine)
+            try {
+                val response = clientA.get(url)
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertEquals(noStoreBody, response.bodyAsText())
+                assertEquals(2, mockInvocations)
+            } finally {
+                clientA.close()
+            }
+
+            val persistedEntries = CacheStorageFactory.create(
+                config = cacheConfig(),
+                fileSystem = FileSystem.SYSTEM,
+                cacheDirectoryProvider = cacheDirectoryProvider()
+            ).findAll(Url(url))
+            assertTrue(persistedEntries.isEmpty(), "no-store response must not be persisted")
+
+            mockInvocations = 0
+            val clientB = buildClient(engine)
+            try {
+                val secondResponse = clientB.get(url)
+                assertEquals(HttpStatusCode.OK, secondResponse.status)
+                assertEquals(noStoreBody, secondResponse.bodyAsText())
+                assertTrue(
+                    mockInvocations >= 2,
+                    "no-store response must not be cached; second client must re-fetch via MockEngine (401 + retry)"
+                )
+            } finally {
+                clientB.close()
+            }
+        }
+
+    private companion object {
+        const val VALID_TOKEN = "refreshed-access-token"
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/ColdStartPersistenceTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/ColdStartPersistenceTest.kt
@@ -1,0 +1,119 @@
+package io.github.santimattius.persistent.cache
+
+import io.github.santimattius.persistent.cache.doubles.FakeCacheDirectoryProvider
+import io.github.santimattius.persistent.cache.doubles.TestClock
+import io.github.santimattius.persistent.cache.doubles.TestDataFactory
+import io.ktor.http.Url
+import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
+import okio.SYSTEM
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Cold-start (app-restart) persistence tests for [OkioFileCacheStorage].
+ *
+ * Per spec (issue #25, domain `okio-file-cache-storage`), a NEW storage
+ * instance built with the REAL filesystem ([FileSystem.SYSTEM]) pointed at
+ * an existing cache directory MUST read entries written there by a prior,
+ * discarded instance. This simulates what actually happens across an app
+ * restart: a fresh process, a fresh object graph, but the same on-disk
+ * directory.
+ *
+ * Deliberately uses [FileSystem.SYSTEM] (not `FakeFileSystem`, which is
+ * in-memory and would trivially "persist" within a single process/test and
+ * would never prove cross-instance, on-disk durability). The clock is still
+ * injected (a [TestClock]) so the TTL-boundary scenario stays deterministic
+ * -- only the filesystem is real.
+ *
+ * Kept in `commonTest` (not `jvmTest`-only) per design: `FileSystem.SYSTEM`
+ * and `FileSystem.SYSTEM_TEMPORARY_DIRECTORY` are backed by a real,
+ * writable directory on the JVM, Android-unit, and iOS-native test targets,
+ * so this test exercises every host this library ships to instead of only
+ * the JVM. If `iosSimulatorArm64Test` fails here specifically because the
+ * simulator can't resolve/write to a temp directory (not an unrelated
+ * flake), the pre-approved fallback documented in tasks/design is to move
+ * this file to `jvmTest`-only and record the reason here.
+ */
+class ColdStartPersistenceTest {
+
+    private lateinit var cacheRootDir: Path
+
+    @BeforeTest
+    fun setUp() {
+        val uniqueSuffix = Random.nextLong().toString()
+        cacheRootDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "ktor-cache-cold-start-test-$uniqueSuffix"
+        FileSystem.SYSTEM.createDirectories(cacheRootDir)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        FileSystem.SYSTEM.deleteRecursively(cacheRootDir, mustExist = false)
+    }
+
+    @Test
+    fun `given entry written by a discarded instance when a fresh instance reads same dir then entry is returned`() =
+        runTest {
+            // Given - instance A writes an entry to a real, on-disk cache directory
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = 60 * 60 * 1000, // 1 hour - won't expire during this test
+                cacheDirectoryProvider = FakeCacheDirectoryProvider(cacheRootDir.toString())
+            )
+            val instanceA = OkioFileCacheStorage(config, FileSystem.SYSTEM, clock::now)
+
+            val url = Url("https://api.example.com/cold-start")
+            val response = TestDataFactory.createCachedResponse(
+                url = url.toString(),
+                body = "persisted across restart"
+            )
+            instanceA.store(url, response)
+
+            // instanceA is now discarded (goes out of scope) -- simulates process death.
+            // Only the on-disk directory (cacheRootDir) survives, exactly like an app restart.
+
+            // When - a brand-new instance is built pointed at the SAME real directory
+            val instanceB = OkioFileCacheStorage(config, FileSystem.SYSTEM, clock::now)
+            val result = instanceB.find(url, emptyMap())
+
+            // Then - the entry written by instance A must be readable by instance B
+            assertNotNull(result, "Fresh instance must read entries written by a prior, discarded instance")
+            assertEquals("persisted across restart", result.body.decodeToString())
+        }
+
+    @Test
+    fun `given entry past ttl boundary when fresh instance reads on cold start then entry is treated as expired`() =
+        runTest {
+            // Given - instance A stores an entry with a short ttl at T
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = 500,
+                cacheDirectoryProvider = FakeCacheDirectoryProvider(cacheRootDir.toString())
+            )
+            val instanceA = OkioFileCacheStorage(config, FileSystem.SYSTEM, clock::now)
+
+            val url = Url("https://api.example.com/cold-start-ttl")
+            instanceA.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
+
+            // instanceA discarded; wall-clock time elapses past the ttl boundary between
+            // "app shutdown" and the next cold start.
+            clock.advance(501)
+
+            // When - a fresh instance (same dir, same elapsed clock) reads at T + 501
+            val instanceB = OkioFileCacheStorage(config, FileSystem.SYSTEM, clock::now)
+            val result = instanceB.find(url, emptyMap())
+
+            // Then - the entry must be treated as expired on the cold read
+            assertNull(result, "Entry past its ttl boundary must be expired on a cold-start read")
+        }
+}

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/InfiniteTtlBehaviorTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/InfiniteTtlBehaviorTest.kt
@@ -1,0 +1,135 @@
+package io.github.santimattius.persistent.cache
+
+import io.github.santimattius.persistent.cache.doubles.FakeCacheDirectoryProvider
+import io.github.santimattius.persistent.cache.doubles.FakeFileSystem
+import io.github.santimattius.persistent.cache.doubles.TestClock
+import io.github.santimattius.persistent.cache.doubles.TestDataFactory
+import io.ktor.http.Url
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Behavioral tests for the "never expires" TTL convention.
+ *
+ * Per spec (issue #25), `config.ttl <= 0` must mean the entry NEVER expires,
+ * mirroring the existing `maxSize <= 0` = "unlimited" convention. This is
+ * verified across both [OkioFileCacheStorage.find] and [OkioFileCacheStorage.findAll]
+ * after advancing the clock far beyond any realistic TTL window.
+ */
+class InfiniteTtlBehaviorTest {
+
+    private lateinit var fakeFileSystem: FakeFileSystem
+
+    @BeforeTest
+    fun setUp() {
+        fakeFileSystem = FakeFileSystem()
+        fakeFileSystem.createDirectory("/fake/cache".toOkioPath())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        fakeFileSystem.clear()
+    }
+
+    @Test
+    fun `given ttl of zero when clock advances far past storage then find still returns entry`() =
+        runTest {
+            // Given - ttl = 0 means "never expires"
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = 0,
+                cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
+            )
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
+
+            val url = Url("https://api.example.com/data")
+            storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
+
+            // When - Advance clock far beyond any realistic TTL window
+            clock.advance(10_000_000)
+
+            // Then - Entry must still be found (never expires)
+            val result = storage.find(url, emptyMap())
+            assertNotNull(result, "Entry with ttl=0 must never expire")
+        }
+
+    @Test
+    fun `given ttl of negative one when clock advances far past storage then find still returns entry`() =
+        runTest {
+            // Given - ttl < 0 also means "never expires"
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = -1,
+                cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
+            )
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
+
+            val url = Url("https://api.example.com/data")
+            storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
+
+            // When - Advance clock far beyond any realistic TTL window
+            clock.advance(10_000_000)
+
+            // Then - Entry must still be found (never expires)
+            val result = storage.find(url, emptyMap())
+            assertNotNull(result, "Entry with ttl=-1 must never expire")
+        }
+
+    @Test
+    fun `given ttl of zero when clock advances far past storage then findAll still returns entry`() =
+        runTest {
+            // Given - ttl = 0 means "never expires"
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = 0,
+                cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
+            )
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
+
+            val url = Url("https://api.example.com/data")
+            storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
+
+            // When - Advance clock far beyond any realistic TTL window
+            clock.advance(10_000_000)
+
+            // Then - findAll must still return the entry (never expires)
+            val results = storage.findAll(url)
+            assertNotNull(results.firstOrNull(), "Entry with ttl=0 must never expire via findAll")
+        }
+
+    @Test
+    fun `given ttl of negative one when clock advances far past storage then findAll still returns entry`() =
+        runTest {
+            // Given - ttl < 0 also means "never expires"
+            val clock = TestClock()
+            val config = OkioFileCacheConfig(
+                fileName = "http_cache",
+                maxSize = 10L * 1024 * 1024,
+                ttl = -1,
+                cacheDirectoryProvider = FakeCacheDirectoryProvider("/fake/cache")
+            )
+            val storage = OkioFileCacheStorage(config, fakeFileSystem, clock::now)
+
+            val url = Url("https://api.example.com/data")
+            storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
+
+            // When - Advance clock far beyond any realistic TTL window
+            clock.advance(10_000_000)
+
+            // Then - findAll must still return the entry (never expires)
+            val results = storage.findAll(url)
+            assertNotNull(results.firstOrNull(), "Entry with ttl=-1 must never expire via findAll")
+        }
+
+    private fun String.toOkioPath(): okio.Path = this.toPath()
+}

--- a/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/TtlConsistencyBehaviorTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/santimattius/persistent/cache/TtlConsistencyBehaviorTest.kt
@@ -250,8 +250,8 @@ class TtlConsistencyBehaviorTest {
     }
 
     @Test
-    fun `given zero ttl config when entry stored then immediately expires`() = runTest {
-        // Given - TTL of 0 means immediate expiration
+    fun `given zero ttl config when entry stored then never expires`() = runTest {
+        // Given - TTL of 0 means "never expires" (mirrors maxSize <= 0 = unlimited)
         val clock = TestClock()
         val config = OkioFileCacheConfig(
             fileName = "http_cache",
@@ -264,14 +264,14 @@ class TtlConsistencyBehaviorTest {
         val url = Url("https://api.example.com/data")
         storage.store(url, TestDataFactory.createCachedResponse(url = url.toString()))
 
-        // Advance clock by 1ms so elapsed > ttl (0)
-        clock.advance(1)
+        // Advance clock well past any realistic window
+        clock.advance(10_000_000)
 
         // When
         val result = storage.find(url, emptyMap())
 
-        // Then - Should be expired immediately
-        assertNull(result, "Entry with zero TTL should be expired immediately")
+        // Then - Should never expire
+        assertNotNull(result, "Entry with zero TTL should never expire")
     }
 
     private fun String.toOkioPath(): okio.Path = this.toPath()


### PR DESCRIPTION
## Summary

Fixes #25 — Android manual context injection, infinite TTL convention, and test/doc coverage for cross-restart persistence and Auth plugin coexistence.

This PR closes the gap between the documented public API and the implementation, adds a documented `cacheTtl <= 0` “never expires” convention (mirroring `maxCacheSize <= 0`), and adds integration tests that prove on-disk durability and Auth + `installPersistentCache` behavior.

## Changes

### Public Android context injection
- **`injectContext`** is now **public** in `io.github.santimattius.persistent.cache.startup` (was `internal`), matching the README manual-init sample.
- Leak-safety check unchanged: still throws `IllegalArgumentException` for leak-prone contexts (e.g. Activity).

### Infinite TTL convention
- **`OkioFileCacheStorage.isExpired()`** returns `false` when `config.ttl <= 0` (entries never expire).
- KDoc updated on `CacheConfig.cacheTtl` and `OkioFileCacheConfig.ttl`.
- **Behavior change:** `cacheTtl = 0` previously expired entries immediately; it now means “never expire” (undocumented edge case, aligned with `maxCacheSize <= 0` = unlimited).

### Tests
- **`InfiniteTtlBehaviorTest`** — `ttl = 0` / `ttl = -1` entries survive clock advances (`find` + `findAll`).
- **`ColdStartPersistenceTest`** — real `FileSystem.SYSTEM` temp dir; a fresh `OkioFileCacheStorage` reads entries written by a discarded instance (cold start + TTL boundary). Runs in `commonTest` (JVM + iOS simulator).
- **`AuthPluginInteropTest`** — `MockEngine` 401 → Bearer refresh → retry with `installPersistentCache`:
  - `Cache-Control: private, max-age=…` → persisted to Okio, served from disk on a second client.
  - `Cache-Control: no-store` → not persisted.

### Documentation
- README: explicit `injectContext` import, RFC 7234 cross-restart caching note, `cacheTtl <= 0` convention, **Auth + persistent cache** caveat (`private` Cache-Control + `isShared = false` when using Auth on the same client).

## Test plan

- [x] `./gradlew :shared:check` (69 tests, JVM + iOS simulator)
- [x] `./gradlew :shared:compileAndroidMain`

## Notes for reviewers

- No changes to Ktor `HttpCache` freshness logic — only storage TTL guard + coverage/docs.
- Auth interop tests document Ktor routing: authenticated responses need **`Cache-Control: private`** to land in private Okio storage; **`isShared = false`** avoids Ktor skipping cache for authorized requests.

---

Puedes pegarlo tal cual en el body del PR. Si querés, también lo adapto al formato de tu `pull_request_template.md`.